### PR TITLE
Add Image block support

### DIFF
--- a/src/blocks.json
+++ b/src/blocks.json
@@ -149,5 +149,66 @@
       },
       "required": []
     }
+  },
+  "image": {
+    "description": "The Image block is used to display an (internal or external) image  with title, description and alt text. It can also be linked to a URL or internal path. It can be aligned and size of the image can be adjusted.",
+    "inputSchema": {
+      "blockData": {
+        "url": {
+          "type": "string",
+          "description": "Internal or External image URL"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title for the image"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description for the image."
+        },
+        "alt": {
+          "type": "string",
+          "description": "Alternative text for the image, used for accessibility"
+        },
+        "href": {
+          "type": "string",
+          "description": "Link target (URL or internal path) when the image is clicked."
+        },
+        "align": {
+          "type": "string",
+          "enum": ["left", "center", "right"],
+          "description": "Image alignment within the block",
+          "default": "center"
+        },
+        "size": {
+          "type": "string",
+          "enum": ["s", "m", "l"],
+          "description": "Image size within the block",
+          "default": "l"
+        },
+        "theme": {
+          "type": "string",
+          "enum": ["default", "grey"],
+          "description": "Background theme for the block",
+          "default": "default"
+        },
+        "styles": {
+          "blockWidth:noprefix": {
+            "--block-width": {
+              "type": "string",
+              "enum": [
+                "var(--narrow-container-width)",
+                "var(--default-container-width)",
+                "var(--layout-container-width)",
+                "unset"
+              ],
+              "description": "Width available for the block on the page layout, narrow-width is the smallest (used by text blocks for readibility), default-width is adequate for most blocks, layout-width is the full width of the main content area, and 100% is the full width of the viewport.",
+              "default": "var(--default-container-width)"
+            }
+          }
+        }
+      },
+      "required": []
+    }
   }
 }

--- a/src/blocks.json
+++ b/src/blocks.json
@@ -202,7 +202,7 @@
                 "var(--layout-container-width)",
                 "unset"
               ],
-              "description": "Width available for the block on the page layout, narrow-width is the smallest (used by text blocks for readibility), default-width is adequate for most blocks, layout-width is the full width of the main content area, and 100% is the full width of the viewport.",
+              "description": "Width available for the block on the page layout, narrow-width is the smallest (used by text blocks for readibility), default-width is adequate for most blocks, layout-width is the full width of the main content area, and 100% is the full width of the viewport. This setting is ONLY available when the align style is set to center.",
               "default": "var(--default-container-width)"
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1074,7 +1074,6 @@ class PloneMCPServer {
 
       // Process block using centralized logic
       blocks[blockId] = this.processBlock(blockType, blockData);
-
       // Insert at specified position or at the end
       if (
         position !== undefined &&
@@ -1200,7 +1199,7 @@ class PloneMCPServer {
 
   // Check if the url is an image address, to avoid creation of blank image blocks
   private isImageURL(url: string): boolean {
-    return /\.(jpeg|jpg|gif|png|svg)$/.test(url);
+    return /\.(jpeg|jpg|gif|png|svg)(\?.*)?(#.*)?$/i.test(url);
   }
 
   // IMPROVEMENT: Check for expired prepared blocks
@@ -1309,7 +1308,8 @@ class PloneMCPServer {
         ],
         theme: blockData.theme || "default",
       };
-    } else if (blockType === "image") {
+    }
+    else if (blockType === "image") {
       //check if url received is an url for image
       if (!this.isImageURL(blockData.url)) {
         throw this.wrapError("ProcessBlock", `Invalid image URL: ${blockData.url}`);
@@ -1318,7 +1318,8 @@ class PloneMCPServer {
         ...blockData,
         "@type": "image",
       }
-    } else {
+    }
+    else {
       return {
         ...blockData,
         "@type": blockType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1043,11 +1043,10 @@ class PloneMCPServer {
         content: [
           {
             type: "text" as const,
-            text: `Successfully prepared ${
-              blocks.length
-            } blocks for next create/update operation (valid for 60 seconds). Blocks ready: ${blockIds.join(
-              ", "
-            )}`,
+            text: `Successfully prepared ${blocks.length
+              } blocks for next create/update operation (valid for 60 seconds). Blocks ready: ${blockIds.join(
+                ", "
+              )}`,
           },
         ],
       };
@@ -1199,6 +1198,11 @@ class PloneMCPServer {
   // SECTION 5: HELPER METHODS
   // =============================================================================
 
+  // Check if the url is an image address, to avoid creation of blank image blocks
+  private isImageURL(url: string): boolean {
+    return /\.(jpeg|jpg|gif|png|svg)$/.test(url);
+  }
+
   // IMPROVEMENT: Check for expired prepared blocks
   private isExpiredPreparedBlocks(): boolean {
     if (!this.preparedBlocks) return true;
@@ -1305,8 +1309,16 @@ class PloneMCPServer {
         ],
         theme: blockData.theme || "default",
       };
+    } else if (blockType === "image") {
+      //check if url received is an url for image
+      if (!this.isImageURL(blockData.url)) {
+        throw this.wrapError("ProcessBlock", `Invalid image URL: ${blockData.url}`);
+      }
+      return {
+        ...blockData,
+        "@type": "image",
+      }
     } else {
-      // For other block types, use the provided data with correct @type
       return {
         ...blockData,
         "@type": blockType,
@@ -1494,9 +1506,8 @@ class PloneMCPServer {
             role: "user",
             content: {
               type: "text" as const,
-              text: `My goal is to create a new ${contentType} page about "${purpose}"${
-                audience ? ` for an audience of ${audience}` : ""
-              }. Perform the following steps:
+              text: `My goal is to create a new ${contentType} page about "${purpose}"${audience ? ` for an audience of ${audience}` : ""
+                }. Perform the following steps:
 
 1.  Ensure the Plone connection is configured.
 2.  Determine the best parent path for this new content.
@@ -1541,9 +1552,8 @@ Begin with the first step.`,
             role: "user",
             content: {
               type: "text" as const,
-              text: `My goal is to create an example site with ${numberOfPages} pages of type ${contentTypes}, all centered around the theme of "${purpose}"${
-                audience ? `, aimed at an audience of ${audience}` : ""
-              }. Follow this plan:
+              text: `My goal is to create an example site with ${numberOfPages} pages of type ${contentTypes}, all centered around the theme of "${purpose}"${audience ? `, aimed at an audience of ${audience}` : ""
+                }. Follow this plan:
 
 1.  Ensure the Plone connection is configured.
 2.  Establish a logical folder (Document type objects can be used as folders) structure for the new pages.


### PR DESCRIPTION
This PR adds image block support with isImageURL validator function , it will take any image url (internal or external ); also if we just ask llm to use an image of flower/laptop etc it would do so , but with the validation in place llm's don't perform well in finding the image with restrictions  , if we remove the validator then it can find images related to the topics and use that image and it's pretty good at finding relatable images .

I added an isImageURL basic validator function, because on using a url other than images it was adding a non-functional block with broken urls  

